### PR TITLE
Create and store clave access code

### DIFF
--- a/prisma/migrations/20240229030819_add_clave_access_code/migration.sql
+++ b/prisma/migrations/20240229030819_add_clave_access_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "claveAccessCode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,11 +12,12 @@ datasource db {
 }
 
 model User {
-  id          Int     @id @default(autoincrement())
-  chipId      String  @unique
-  email       String  @unique
-  displayName String
-  claveWallet String?
+  id              Int     @id @default(autoincrement())
+  chipId          String  @unique
+  email           String  @unique
+  displayName     String
+  claveWallet     String?
+  claveAccessCode String?
 
   encryptionPublicKey String
   signaturePublicKey  String

--- a/src/lib/server/clave-api.ts
+++ b/src/lib/server/clave-api.ts
@@ -1,0 +1,18 @@
+export async function createClaveAccessCode() {
+  return await fetch("https://api.getclave.io/api/v1/waitlist/codes/single", {
+    method: "POST",
+    headers: {
+      "x-api-key": process.env.CLAVE_API_KEY!,
+      "Content-Type": "application/json",
+    },
+  }).then(async (r) => {
+    if (!r.ok) {
+      console.log(r.status);
+      console.log(await r.text());
+      throw new Error("Request Clave access code failed");
+    }
+
+    const result = await r.json();
+    return result as { code: string };
+  });
+}

--- a/src/pages/api/register/create_account.ts
+++ b/src/pages/api/register/create_account.ts
@@ -14,6 +14,7 @@ import {
   getChipTypeFromChipId,
   verifyEmailForChipId,
 } from "@/lib/server/iyk";
+import { createClaveAccessCode } from "@/lib/server/clave-api";
 
 const createAccountSchema = object({
   iykRef: string().required(),
@@ -113,6 +114,9 @@ export default async function handler(
     return res.status(400).json({ error: "Invalid email code" });
   }
 
+  // Create Clave access code
+  const { code: claveAccessCode } = await createClaveAccessCode();
+
   // Create user
   const user = await prisma.user.create({
     data: {
@@ -126,6 +130,7 @@ export default async function handler(
       psiRound1Message,
       passwordSalt,
       passwordHash,
+      claveAccessCode,
     },
   });
 


### PR DESCRIPTION
_What was changed?_
- Add a util function to generate a Clave access code
- Add db migration for nullable `claveAccessCode`
- Store access for new reason after successful registration